### PR TITLE
Fix version string (before: 1.xx+devel, now: 1.xx)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -49,7 +49,7 @@ pushd $REPODIR/src/main/resources/de/thomas_oster/visicut/gui/resources/
 for i in VisicutApp*.properties
 do
 	cp $i /tmp/$i
-	cat /tmp/$i|sed "s#version = .*#version = $VERSION#g#" > $i
+	cat /tmp/$i|sed "s#^Application.version =.*#Application.version = $VERSION#g#" > $i
 	rm /tmp/$i
 done
 popd


### PR DESCRIPTION
This regression was caused by changes in VisiCut.
After this fix, the download links on the website should work again.